### PR TITLE
fix panic when stopping cell with bi-directional subscriptions

### DIFF
--- a/cells/cells_test.go
+++ b/cells/cells_test.go
@@ -214,6 +214,25 @@ func TestBehaviorEmitTimeout(t *testing.T) {
 	assert.Equal(ci.EmitTimeout(), cells.MaxEmitTimeout)
 }
 
+// TestEnvironmentSubscribeStop subscribing and stopping
+func TestEnvironmentSubscribeStop(t *testing.T) {
+	assert := audit.NewTestingAssertion(t, true)
+
+	env := cells.NewEnvironment("subscribe-unsubscribe-stop")
+	defer env.Stop()
+
+	assert.Nil(env.StartCell("foo", newTestBehavior()))
+	assert.Nil(env.StartCell("bar", newTestBehavior()))
+	assert.Nil(env.StartCell("baz", newTestBehavior()))
+
+	assert.Nil(env.Subscribe("foo", "bar", "baz"))
+	assert.Nil(env.Subscribe("bar", "foo", "baz"))
+
+	assert.Nil(env.StopCell("bar"))
+	assert.Nil(env.StopCell("foo"))
+	assert.Nil(env.StopCell("baz"))
+}
+
 // TestEnvironmentSubscribeUnsubscribe tests subscribing,
 // checking and unsubscribing of cells.
 func TestEnvironmentSubscribeUnsubscribe(t *testing.T) {

--- a/cells/registry.go
+++ b/cells/registry.go
@@ -32,11 +32,23 @@ type celler struct {
 // stop unsubscribes from the subscriptions and stops the cell.
 func (cr *celler) stop() error {
 	subscriberID := cr.cell.ID()
-	for id := range cr.subscriptions {
+	for id := range cr.subscribers {
 		ucr := cr.registry.cellers[id]
-		delete(ucr.subscribers, subscriberID)
+		delete(ucr.subscriptions, subscriberID)
 		if err := ucr.updateSubscribers(); err != nil {
 			return err
+		}
+	}
+	for id := range cr.subscriptions {
+		ucr, ok := cr.registry.cellers[id]
+		if !ok {
+			panic("subscriptions out of sync with cellers")
+			//delete(cr.subscriptions, id)
+		} else {
+			delete(ucr.subscribers, subscriberID)
+			if err := ucr.updateSubscribers(); err != nil {
+				return err
+			}
 		}
 	}
 	return cr.cell.stop()


### PR DESCRIPTION
When A subscribes to B and B subscribes to A, and you stop A, and then B, the call to stop B panics because there is a leftover entry in its subscriptions field.

The new test case will panic without the fix.