### PR TITLE
Release v4.22.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
   for correct logging in functions and packages providing
   own test functions based on *audit*
 - Code reorganisation in *audit*
+- Extended *Range()* assertion in *audit* by time
+  and duration
 
 ## 2017-03-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Tideland Go Library
 
-## 2017-03-xx
+## 2017-03-19
 
 - Fixing of races in tests in *loop* and *monitoring*
 - Added *IncrCallstackOffset()* to *audit.Assertion*
@@ -9,6 +9,8 @@
 - Code reorganisation in *audit*
 - Extended *Range()* assertion in *audit* by time
   and duration
+- Added *FailureDetail* returned by *ValidationFailer.Details()*
+  in *audit*
 
 ## 2017-03-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 2017-03-19
 
+- Readesigned *cache*; now individual instances with
+  user definable loaders
 - Fixing of races in tests in *loop* and *monitoring*
 - Added *IncrCallstackOffset()* to *audit.Assertion*
   for correct logging in functions and packages providing

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Tideland Go Library
 
+## 2017-03-xx
+
+- Fixing of races in tests in *loop* and *monitoring*
+- Added *IncrCallstackOffset()* to *audit.Assertion*
+  for correct logging in functions and packages providing
+  own test functions based on *audit*
+- Code reorganisation in *audit*
+
 ## 2017-03-13
 
 - Fixed flaky tests in *timex* package

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ I hope you like them. ;)
 
 ## Version
 
-Version 4.21.3
+Version 4.22.0
 
 ## Packages
 
@@ -31,7 +31,7 @@ to generate test data.
 
 ### Cache
 
-Lazy Loading and Caching of Values.
+Individual caches for types implementing an interface.
 
 [![GoDoc](https://godoc.org/github.com/tideland/golib/cache?status.svg)](https://godoc.org/github.com/tideland/golib/cache)
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ to generate test data.
 
 ### Cache
 
-Individual caches for types implementing an interface.
+Individual caches for types implementing the Cacheable interface.
 
 [![GoDoc](https://godoc.org/github.com/tideland/golib/cache?status.svg)](https://godoc.org/github.com/tideland/golib/cache)
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ and extended into the repository
 
 I hope you like them. ;)
 
+[![Sourcegraph](https://sourcegraph.com/github.com/tideland/golib/-/badge.svg)](https://sourcegraph.com/github.com/tideland/golb?badge)
+
 ## Version
 
 Version 4.21.2

--- a/audit/asserts.go
+++ b/audit/asserts.go
@@ -12,16 +12,8 @@ package audit
 //--------------------
 
 import (
-	"bytes"
-	"errors"
 	"fmt"
-	"os"
-	"path"
-	"reflect"
-	"regexp"
-	"runtime"
 	"strings"
-	"sync"
 	"time"
 )
 
@@ -32,6 +24,7 @@ import (
 // Test represents the test inside an assert.
 type Test uint
 
+// Tests provided by the assertion.
 const (
 	Invalid Test = iota + 1
 	True
@@ -60,254 +53,24 @@ const (
 	Fail
 )
 
-var testNames = []string{
-	Invalid:      "invalid",
-	True:         "true",
-	False:        "false",
-	Nil:          "nil",
-	NotNil:       "not nil",
-	Equal:        "equal",
-	Different:    "different",
-	Contents:     "contents",
-	About:        "about",
-	Range:        "range",
-	Substring:    "substring",
-	Case:         "case",
-	Match:        "match",
-	ErrorMatch:   "error match",
-	Implementor:  "implementor",
-	Assignable:   "assignable",
-	Unassignable: "unassignable",
-	Empty:        "empty",
-	NotEmpty:     "not empty",
-	Length:       "length",
-	Panics:       "panics",
-	PathExists:   "path exists",
-	Wait:         "wait",
-	Retry:        "retry",
-	Fail:         "fail",
-}
-
-func (t Test) String() string {
-	if int(t) < len(testNames) {
-		return testNames[t]
-	}
-	return "invalid"
-}
-
-//--------------------
-// PRINTER
-//--------------------
-
-// Printer allows to switch between different outputs.
-type Printer interface {
-	// Printf prints a formatted information.
-	Printf(format string, args ...interface{})
-}
-
-// printerBackend is the globally printer used during
-// the assertions.
-var (
-	printerBackend Printer = &fmtPrinter{}
-	mux            sync.Mutex
-)
-
-// fmtPrinter uses the standard fmt package for printing.
-type fmtPrinter struct{}
-
-// Printf implements the Printer interface.
-func (p *fmtPrinter) Printf(format string, args ...interface{}) {
-	fmt.Printf(format, args...)
-}
-
-// SetPrinter sets a new global printer and returns the
-// current one.
-func SetPrinter(p Printer) Printer {
-	mux.Lock()
-	defer mux.Unlock()
-	cp := printerBackend
-	printerBackend = p
-	return cp
-}
-
-// backendPrintf uses the printer backend for output. It is used
-// in the types below.
-func backendPrintf(format string, args ...interface{}) {
-	mux.Lock()
-	defer mux.Unlock()
-	printerBackend.Printf(format, args...)
-}
-
-//--------------------
-// FAILER
-//--------------------
-
-// Failer describes a type controlling how an assert
-// reacts after a failure.
-type Failer interface {
-	// Logf can be used to display useful information during testing.
-	Logf(format string, args ...interface{})
-
-	// Fail will be called if an assert fails.
-	Fail(test Test, obtained, expected interface{}, msgs ...string) bool
-}
-
-// Failures collects the collected failures
-// of a validation assertion.
-type Failures interface {
-	// HasErrors returns true, if assertion failures happened.
-	HasErrors() bool
-
-	// Errors returns the so far collected errors.
-	Errors() []error
-
-	// Error returns the collected errors as one error.
-	Error() error
-}
-
-// panicFailer reacts with a panic.
-type panicFailer struct{}
-
-// Logf implements the Failer interface.
-func (f panicFailer) Logf(format string, args ...interface{}) {
-	backendPrintf(format+"\n", args...)
-}
-
-// Fail implements the Failer interface.
-func (f panicFailer) Fail(test Test, obtained, expected interface{}, msgs ...string) bool {
-	obex := obexString(test, obtained, expected)
-	panic(failString(test, obex, msgs...))
-}
-
-// validationFailer collects validation errors, e.g. when
-// validating form input data.
-type validationFailer struct {
-	mux  sync.Mutex
-	errs []error
-}
-
-// HasErrors implements the Failures interface.
-func (f *validationFailer) HasErrors() bool {
-	f.mux.Lock()
-	defer f.mux.Unlock()
-	return len(f.errs) > 0
-}
-
-// Errors implements the Failures interface.
-func (f *validationFailer) Errors() []error {
-	f.mux.Lock()
-	defer f.mux.Unlock()
-	return f.errs
-}
-
-// Error implements the Failures interface.
-func (f *validationFailer) Error() error {
-	f.mux.Lock()
-	defer f.mux.Unlock()
-	strs := []string{}
-	for i, err := range f.errs {
-		strs = append(strs, fmt.Sprintf("[%d] %v", i, err))
-	}
-	return errors.New(strings.Join(strs, " / "))
-}
-
-// Logf implements the Failer interface.
-func (f *validationFailer) Logf(format string, args ...interface{}) {
-	f.mux.Lock()
-	defer f.mux.Unlock()
-	backendPrintf(format+"\n", args...)
-}
-
-// Fail implements the Failer interface.
-func (f *validationFailer) Fail(test Test, obtained, expected interface{}, msgs ...string) bool {
-	f.mux.Lock()
-	defer f.mux.Unlock()
-	obex := obexString(test, obtained, expected)
-	f.errs = append(f.errs, errors.New(failString(test, obex, msgs...)))
-	return false
-}
-
-// Failable allows an assertion to signal a fail to an external instance
-// like testing.T or testing.B.
-type Failable interface {
-	FailNow()
-}
-
-// testingFailer works together with the testing package of Go and
-// may signal the fail to it.
-type testingFailer struct {
-	mux       sync.Mutex
-	failable  Failable
-	shallFail bool
-}
-
-// Logf implements the Failer interface.
-func (f *testingFailer) Logf(format string, args ...interface{}) {
-	f.mux.Lock()
-	defer f.mux.Unlock()
-	pc, file, line, _ := runtime.Caller(2)
-	_, fileName := path.Split(file)
-	funcNameParts := strings.Split(runtime.FuncForPC(pc).Name(), ".")
-	funcNamePartsIdx := len(funcNameParts) - 1
-	funcName := funcNameParts[funcNamePartsIdx]
-	prefix := fmt.Sprintf("%s:%d %s(): ", fileName, line, funcName)
-	backendPrintf(prefix+format+"\n", args...)
-}
-
-// Fail implements the Failer interface.
-func (f *testingFailer) Fail(test Test, obtained, expected interface{}, msgs ...string) bool {
-	f.mux.Lock()
-	defer f.mux.Unlock()
-	pc, file, line, _ := runtime.Caller(2)
-	_, fileName := path.Split(file)
-	funcNameParts := strings.Split(runtime.FuncForPC(pc).Name(), ".")
-	funcNamePartsIdx := len(funcNameParts) - 1
-	funcName := funcNameParts[funcNamePartsIdx]
-	buffer := &bytes.Buffer{}
-	fmt.Fprintf(buffer, "--------------------------------------------------------------------------------\n")
-	if test == Fail {
-		fmt.Fprintf(buffer, "%s:%d: Assert failed!\n\n", fileName, line)
-	} else {
-		fmt.Fprintf(buffer, "%s:%d: Assert '%s' failed!\n\n", fileName, line, test)
-	}
-	fmt.Fprintf(buffer, "Function...: %s()\n", funcName)
-	switch test {
-	case True, False, Nil, NotNil, Empty, NotEmpty, Panics:
-		fmt.Fprintf(buffer, "Obtained...: %v\n", obtained)
-	case Implementor, Assignable, Unassignable:
-		fmt.Fprintf(buffer, "Obtained...: %v\n", ValueDescription(obtained))
-		fmt.Fprintf(buffer, "Expected...: %v\n", ValueDescription(expected))
-	case Contents:
-		switch typedObtained := obtained.(type) {
-		case string:
-			fmt.Fprintf(buffer, "Part.......: %s\n", typedObtained)
-			fmt.Fprintf(buffer, "Full.......: %s\n", expected)
-		default:
-			fmt.Fprintf(buffer, "Part.......: %v\n", obtained)
-			fmt.Fprintf(buffer, "Full.......: %v\n", expected)
-		}
-	case Fail:
-	default:
-		fmt.Fprintf(buffer, "Obtained...: %v\n", obtained)
-		fmt.Fprintf(buffer, "Expected...: %v\n", expected)
-	}
-	if len(msgs) > 0 {
-		fmt.Fprintf(buffer, "Description: %s\n", strings.Join(msgs, "\n             "))
-	}
-	fmt.Fprintf(buffer, "--------------------------------------------------------------------------------\n")
-	backendPrintf(buffer.String())
-	if f.shallFail {
-		f.failable.FailNow()
-	}
-	return false
-}
-
 //--------------------
 // ASSERTION
 //--------------------
 
+// MakeSigChan is a simple one-liner to create the buffered signal channel
+// for the wait assertion.
+func MakeSigChan() chan interface{} {
+	return make(chan interface{}, 1)
+}
+
 // Assertion defines the available test methods.
 type Assertion interface {
+	// IncrCallstackOffset allows test libraries using the audit
+	// package internally to adjust the callstack offset. This
+	// way test output shows the correct location. Deferring
+	// the returned function restores the former offset.
+	IncrCallstackOffset() func()
+
 	// Logf can be used to display useful information during testing.
 	Logf(format string, args ...interface{})
 
@@ -422,6 +185,7 @@ func NewValidationAssertion() (Assertion, Failures) {
 func NewTestingAssertion(f Failable, shallFail bool) Assertion {
 	return NewAssertion(&testingFailer{
 		failable:  f,
+		offset:    2,
 		shallFail: shallFail,
 	})
 }
@@ -430,6 +194,11 @@ func NewTestingAssertion(f Failable, shallFail bool) Assertion {
 type assertion struct {
 	Tester
 	failer Failer
+}
+
+// Logf implements the Assertion interface.
+func (a *assertion) IncrCallstackOffset() func() {
+	return a.failer.IncrCallstackOffset()
 }
 
 // Logf implements the Assertion interface.
@@ -683,228 +452,6 @@ func (a *assertion) Fail(msgs ...string) bool {
 }
 
 //--------------------
-// TESTER
-//--------------------
-
-// Tester is a helper which can be used in own Assertion implementations.
-type Tester struct{}
-
-// IsTrue checks if obtained is true.
-func (t Tester) IsTrue(obtained bool) bool {
-	return obtained == true
-}
-
-// IsNil checks if obtained is nil in a safe way.
-func (t Tester) IsNil(obtained interface{}) bool {
-	if obtained == nil {
-		// Standard test.
-		return true
-	}
-	// Some types have to be tested via reflection.
-	value := reflect.ValueOf(obtained)
-	kind := value.Kind()
-	switch kind {
-	case reflect.Chan, reflect.Func, reflect.Interface, reflect.Map, reflect.Ptr, reflect.Slice:
-		return value.IsNil()
-	}
-	return false
-}
-
-// IsEqual checks if obtained and expected are equal.
-func (t Tester) IsEqual(obtained, expected interface{}) bool {
-	return reflect.DeepEqual(obtained, expected)
-}
-
-// IsAbout checks if obtained and expected are to a given extent almost equal.
-func (t Tester) IsAbout(obtained, expected, extent float64) bool {
-	if extent < 0.0 {
-		extent = extent * (-1)
-	}
-	low := expected - extent
-	high := expected + extent
-	return low <= obtained && obtained <= high
-}
-
-// IsInRange checks, if obtained is inside the given range. In case of a
-// slice, array, or map it will check agains the length.
-func (t Tester) IsInRange(obtained, low, high interface{}) (bool, error) {
-	// First standard types.
-	switch o := obtained.(type) {
-	case byte:
-		l, lok := low.(byte)
-		h, hok := high.(byte)
-		if !lok && !hok {
-			return false, errors.New("low and/or high are no byte")
-		}
-		return l <= o && o <= h, nil
-	case int:
-		l, lok := low.(int)
-		h, hok := high.(int)
-		if !lok && !hok {
-			return false, errors.New("low and/or high are no int")
-		}
-		return l <= o && o <= h, nil
-	case float64:
-		l, lok := low.(float64)
-		h, hok := high.(float64)
-		if !lok && !hok {
-			return false, errors.New("low and/or high are no float64")
-		}
-		return l <= o && o <= h, nil
-	case rune:
-		l, lok := low.(rune)
-		h, hok := high.(rune)
-		if !lok && !hok {
-			return false, errors.New("low and/or high are no rune")
-		}
-		return l <= o && o <= h, nil
-	case string:
-		l, lok := low.(string)
-		h, hok := high.(string)
-		if !lok && !hok {
-			return false, errors.New("low and/or high are no string")
-		}
-		return l <= o && o <= h, nil
-	}
-	// Now check the collection types.
-	ol, err := t.Len(obtained)
-	if err != nil {
-		return false, errors.New("no valid type with a length")
-	}
-	l, lok := low.(int)
-	h, hok := high.(int)
-	if !lok && !hok {
-		return false, errors.New("low and/or high are no int")
-	}
-	return l <= ol && ol <= h, nil
-}
-
-// Contains checks if the part type is matching to the full type and
-// if the full data containes the part data.
-func (t Tester) Contains(part, full interface{}) (bool, error) {
-	switch fullValue := full.(type) {
-	case string:
-		// Content of a string.
-		switch partValue := part.(type) {
-		case string:
-			return strings.Contains(fullValue, partValue), nil
-		case []byte:
-			return strings.Contains(fullValue, string(partValue)), nil
-		default:
-			partString := fmt.Sprintf("%v", partValue)
-			return strings.Contains(fullValue, partString), nil
-		}
-	case []byte:
-		// Content of a byte slice.
-		switch partValue := part.(type) {
-		case string:
-			return bytes.Contains(fullValue, []byte(partValue)), nil
-		case []byte:
-			return bytes.Contains(fullValue, partValue), nil
-		default:
-			partBytes := []byte(fmt.Sprintf("%v", partValue))
-			return bytes.Contains(fullValue, partBytes), nil
-		}
-	default:
-		// Content of any array or slice, use reflection.
-		value := reflect.ValueOf(full)
-		kind := value.Kind()
-		if kind == reflect.Array || kind == reflect.Slice {
-			length := value.Len()
-			for i := 0; i < length; i++ {
-				current := value.Index(i)
-				if reflect.DeepEqual(part, current.Interface()) {
-					return true, nil
-				}
-			}
-			return false, nil
-		}
-	}
-	return false, errors.New("full value is no string, array, or slice")
-}
-
-// IsSubstring checks if obtained is a substring of the full string.
-func (t Tester) IsSubstring(obtained, full string) bool {
-	return strings.Contains(full, obtained)
-}
-
-// IsCase checks if the obtained string is uppercase or lowercase.
-func (t Tester) IsCase(obtained string, upperCase bool) bool {
-	if upperCase {
-		return obtained == strings.ToUpper(obtained)
-	}
-	return obtained == strings.ToLower(obtained)
-}
-
-// IsMatching checks if the obtained string matches a regular expression.
-func (t Tester) IsMatching(obtained, regex string) (bool, error) {
-	return regexp.MatchString("^"+regex+"$", obtained)
-}
-
-// IsImplementor checks if obtained implements the expected interface variable pointer.
-func (t Tester) IsImplementor(obtained, expected interface{}) (bool, error) {
-	obtainedValue := reflect.ValueOf(obtained)
-	expectedValue := reflect.ValueOf(expected)
-	if !obtainedValue.IsValid() {
-		return false, fmt.Errorf("obtained value is invalid: %v", obtained)
-	}
-	if !expectedValue.IsValid() || expectedValue.Kind() != reflect.Ptr || expectedValue.Elem().Kind() != reflect.Interface {
-		return false, fmt.Errorf("expected value is no interface variable pointer: %v", expected)
-	}
-	return obtainedValue.Type().Implements(expectedValue.Elem().Type()), nil
-}
-
-// IsAssignable checks if the types of obtained and expected are assignable.
-func (t Tester) IsAssignable(obtained, expected interface{}) bool {
-	obtainedValue := reflect.ValueOf(obtained)
-	expectedValue := reflect.ValueOf(expected)
-	return obtainedValue.Type().AssignableTo(expectedValue.Type())
-}
-
-// Length checks the len of the obtained string, array, slice, map or channel.
-func (t Tester) Len(obtained interface{}) (int, error) {
-	// Check using the lenable interface.
-	if l, ok := obtained.(lenable); ok {
-		return l.Len(), nil
-	}
-	// Check the standard types.
-	obtainedValue := reflect.ValueOf(obtained)
-	obtainedKind := obtainedValue.Kind()
-	switch obtainedKind {
-	case reflect.Array, reflect.Chan, reflect.Map, reflect.Slice, reflect.String:
-		return obtainedValue.Len(), nil
-	default:
-		descr := ValueDescription(obtained)
-		return 0, fmt.Errorf("obtained %s is no array, chan, map, slice, string or understands Len()", descr)
-	}
-}
-
-// HasPanic checks if the passed function panics.
-func (t Tester) HasPanic(pf func()) (ok bool) {
-	defer func() {
-		if r := recover(); r != nil {
-			// Panic, that's ok!
-			ok = true
-		}
-	}()
-	pf()
-	return false
-}
-
-// IsValidPath checks if the given directory or
-// file path exists.
-func (t Tester) IsValidPath(path string) (bool, error) {
-	_, err := os.Stat(path)
-	if err == nil {
-		return true, nil
-	}
-	if os.IsNotExist(err) {
-		return false, nil
-	}
-	return true, err
-}
-
-//--------------------
 // HELPER
 //--------------------
 
@@ -912,30 +459,6 @@ func (t Tester) IsValidPath(path string) (bool, error) {
 type lowHigh struct {
 	low  interface{}
 	high interface{}
-}
-
-// ValueDescription returns a description of a value as string.
-func ValueDescription(value interface{}) string {
-	rvalue := reflect.ValueOf(value)
-	kind := rvalue.Kind()
-	switch kind {
-	case reflect.Array, reflect.Chan, reflect.Map, reflect.Slice:
-		return kind.String() + " of " + rvalue.Type().Elem().String()
-	case reflect.Func:
-		return kind.String() + " " + rvalue.Type().Name() + "()"
-	case reflect.Interface, reflect.Struct:
-		return kind.String() + " " + rvalue.Type().Name()
-	case reflect.Ptr:
-		return kind.String() + " to " + rvalue.Type().Elem().String()
-	}
-	// Default.
-	return kind.String()
-}
-
-// MakeSigChan is a simple one-liner to create the buffered signal channel
-// for the wait assertion.
-func MakeSigChan() chan interface{} {
-	return make(chan interface{}, 1)
 }
 
 // lenable is an interface for the Len() mehod.

--- a/audit/asserts.go
+++ b/audit/asserts.go
@@ -101,8 +101,10 @@ type Assertion interface {
 	About(obtained, expected, extent float64, msgs ...string) bool
 
 	// Range tests if obtained is larger or equal low and lower or
-	// equal high. Allowed are byte, int and float64 for numbers, runes
-	// and strings, or as a length test array, slices, and maps.
+	// equal high. Allowed are byte, int and float64 for numbers, runes,
+	// strings, times, and duration. In case of obtained arrays,
+	// slices, and maps low and high have to be ints for testing
+	// the length.
 	Range(obtained, low, high interface{}, msgs ...string) bool
 
 	// Substring tests if obtained is a substring of the full string.

--- a/audit/asserts.go
+++ b/audit/asserts.go
@@ -168,30 +168,6 @@ func NewAssertion(f Failer) Assertion {
 	}
 }
 
-// NewPanicAssertion creates a new Assertion instance which panics if a test fails.
-func NewPanicAssertion() Assertion {
-	return NewAssertion(&panicFailer{})
-}
-
-// NewValidationAssertion creates a new Assertion instance which collections
-// validation failures. The returned Failures instance allows to test an access
-// them.
-func NewValidationAssertion() (Assertion, Failures) {
-	vf := &validationFailer{}
-	return NewAssertion(vf), vf
-}
-
-// NewTestingAssertion creates a new Assertion instance for use with the testing
-// package. The *testing.T has to be passed as failable, the first argument.
-// shallFail controls if a failing assertion also lets fail the Go test.
-func NewTestingAssertion(f Failable, shallFail bool) Assertion {
-	return NewAssertion(&testingFailer{
-		failable:  f,
-		offset:    2,
-		shallFail: shallFail,
-	})
-}
-
 // assertion implements the assertion interface.
 type assertion struct {
 	Tester

--- a/audit/asserts_test.go
+++ b/audit/asserts_test.go
@@ -396,6 +396,27 @@ func TestValidationAssertion(t *testing.T) {
 		t.Errorf("wrong number of errors")
 	}
 	t.Log(failures.Error())
+
+	if len(failures.Details()) != 2 {
+		t.Errorf("wrong number of details")
+	}
+	details := failures.Details()
+	fn, l, f := details[0].Location()
+	tt := details[0].Test()
+	if fn != "asserts_test.go" || l != 389 || f != "TestValidationAssertion" {
+		t.Errorf("wrong location of first detail")
+	}
+	if tt != audit.True {
+		t.Errorf("wrong test type of first detail")
+	}
+	fn, l, f = details[1].Location()
+	tt = details[1].Test()
+	if fn != "asserts_test.go" || l != 390 || f != "TestValidationAssertion" {
+		t.Errorf("wrong location of second detail")
+	}
+	if tt != audit.Equal {
+		t.Errorf("wrong test type of second detail")
+	}
 }
 
 //--------------------

--- a/audit/asserts_test.go
+++ b/audit/asserts_test.go
@@ -158,6 +158,15 @@ func TestAssertContentsPrint(t *testing.T) {
 	assert.Contents([]byte("foobar"), []byte("the quick brown ..."), "test fails but passes, just visualization")
 }
 
+// TestOffsetPrint test the correct visualization when printing
+// with offset.
+func TestOffsetPrint(t *testing.T) {
+	assert := audit.NewTestingAssertion(t, false)
+
+	// Log should reference line below (167).
+	failWithOffset(assert, "167")
+}
+
 // TestAssertSubstring tests the Substring() assertion.
 func TestAssertSubstring(t *testing.T) {
 	successfulAssert := successfulAssertion(t)
@@ -393,6 +402,10 @@ type metaFailer struct {
 	fail bool
 }
 
+func (f *metaFailer) IncrCallstackOffset() func() {
+	return func() {}
+}
+
 func (f *metaFailer) Logf(format string, args ...interface{}) {
 	f.t.Logf(format, args...)
 }
@@ -410,6 +423,18 @@ func (f *metaFailer) Fail(test audit.Test, obtained, expected interface{}, msgs 
 		f.t.FailNow()
 	}
 	return f.fail
+}
+
+//--------------------
+// HELPER
+//--------------------
+
+// failWithOffset checks the offset increment.
+func failWithOffset(assert audit.Assertion, line string) {
+	restore := assert.IncrCallstackOffset()
+	defer restore()
+
+	assert.Fail("should fail referencing line " + line)
 }
 
 // successfulAssertion returns an assertion which doesn't expect a failing.

--- a/audit/asserts_test.go
+++ b/audit/asserts_test.go
@@ -116,12 +116,15 @@ func TestAssertAbout(t *testing.T) {
 func TestAssertRange(t *testing.T) {
 	successfulAssert := successfulAssertion(t)
 	failingAssert := failingAssertion(t)
+	now := time.Now()
 
 	successfulAssert.Range(byte(9), byte(1), byte(22), "byte in range")
 	successfulAssert.Range(9, 1, 22, "int in range")
 	successfulAssert.Range(9.0, 1.0, 22.0, "float64 in range")
 	successfulAssert.Range('f', 'a', 'z', "rune in range")
 	successfulAssert.Range("foo", "a", "zzzzz", "string in range")
+	successfulAssert.Range(now, now.Add(-time.Hour), now.Add(time.Hour), "time in range")
+	successfulAssert.Range(time.Minute, time.Second, time.Hour, "duration in range")
 	successfulAssert.Range([]int{1, 2, 3}, 1, 10, "slice length in range")
 	successfulAssert.Range([3]int{1, 2, 3}, 1, 10, "array length in range")
 	successfulAssert.Range(map[int]int{3: 1, 2: 2, 1: 3}, 1, 10, "map length in range")
@@ -130,6 +133,8 @@ func TestAssertRange(t *testing.T) {
 	failingAssert.Range(1.0, 10.0, 20.0, "float64 out of range")
 	failingAssert.Range('a', 'x', 'z', "rune out of range")
 	failingAssert.Range("aaa", "uuuuu", "zzzzz", "string out of range")
+	failingAssert.Range(now, now.Add(time.Minute), now.Add(time.Hour), "time out of range")
+	failingAssert.Range(time.Second, time.Minute, time.Hour, "duration in range")
 	failingAssert.Range([]int{1, 2, 3}, 5, 10, "slice length out of range")
 	failingAssert.Range([3]int{1, 2, 3}, 5, 10, "array length out of range")
 	failingAssert.Range(map[int]int{3: 1, 2: 2, 1: 3}, 5, 10, "map length out of range")
@@ -164,7 +169,7 @@ func TestOffsetPrint(t *testing.T) {
 	assert := audit.NewTestingAssertion(t, false)
 
 	// Log should reference line below (167).
-	failWithOffset(assert, "167")
+	failWithOffset(assert, "172")
 }
 
 // TestAssertSubstring tests the Substring() assertion.

--- a/audit/failer.go
+++ b/audit/failer.go
@@ -1,0 +1,217 @@
+// Tideland Go Library - Audit
+//
+// Copyright (C) 2012-2017 Frank Mueller / Tideland / Oldenburg / Germany
+//
+// All rights reserved. Use of this source code is governed
+// by the new BSD license.
+
+package audit
+
+//--------------------
+// IMPORTS
+//--------------------
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"path"
+	"runtime"
+	"strings"
+	"sync"
+)
+
+//--------------------
+// FAILER
+//--------------------
+
+// Failer describes a type controlling how an assert
+// reacts after a failure.
+type Failer interface {
+	// IncrCallstackOffset increases the callstack offset for
+	// the assertion output (see Assertion) and returns a function
+	// for restoring.
+	IncrCallstackOffset() func()
+
+	// Logf can be used to display useful information during testing.
+	Logf(format string, args ...interface{})
+
+	// Fail will be called if an assert fails.
+	Fail(test Test, obtained, expected interface{}, msgs ...string) bool
+}
+
+// Failures collects the collected failures
+// of a validation assertion.
+type Failures interface {
+	// HasErrors returns true, if assertion failures happened.
+	HasErrors() bool
+
+	// Errors returns the so far collected errors.
+	Errors() []error
+
+	// Error returns the collected errors as one error.
+	Error() error
+}
+
+// panicFailer reacts with a panic.
+type panicFailer struct{}
+
+// IncrCallstackOffset implements the Failer interface.
+func (f panicFailer) IncrCallstackOffset() func() {
+	return func() {}
+}
+
+// Logf implements the Failer interface.
+func (f panicFailer) Logf(format string, args ...interface{}) {
+	backendPrintf(format+"\n", args...)
+}
+
+// Fail implements the Failer interface.
+func (f panicFailer) Fail(test Test, obtained, expected interface{}, msgs ...string) bool {
+	obex := obexString(test, obtained, expected)
+	panic(failString(test, obex, msgs...))
+}
+
+// validationFailer collects validation errors, e.g. when
+// validating form input data.
+type validationFailer struct {
+	mux  sync.Mutex
+	errs []error
+}
+
+// HasErrors implements the Failures interface.
+func (f *validationFailer) HasErrors() bool {
+	f.mux.Lock()
+	defer f.mux.Unlock()
+	return len(f.errs) > 0
+}
+
+// Errors implements the Failures interface.
+func (f *validationFailer) Errors() []error {
+	f.mux.Lock()
+	defer f.mux.Unlock()
+	return f.errs
+}
+
+// Error implements the Failures interface.
+func (f *validationFailer) Error() error {
+	f.mux.Lock()
+	defer f.mux.Unlock()
+	strs := []string{}
+	for i, err := range f.errs {
+		strs = append(strs, fmt.Sprintf("[%d] %v", i, err))
+	}
+	return errors.New(strings.Join(strs, " / "))
+}
+
+// IncrCallstackOffset implements the Failer interface.
+func (f *validationFailer) IncrCallstackOffset() func() {
+	return func() {}
+}
+
+// Logf implements the Failer interface.
+func (f *validationFailer) Logf(format string, args ...interface{}) {
+	f.mux.Lock()
+	defer f.mux.Unlock()
+	backendPrintf(format+"\n", args...)
+}
+
+// Fail implements the Failer interface.
+func (f *validationFailer) Fail(test Test, obtained, expected interface{}, msgs ...string) bool {
+	f.mux.Lock()
+	defer f.mux.Unlock()
+	obex := obexString(test, obtained, expected)
+	f.errs = append(f.errs, errors.New(failString(test, obex, msgs...)))
+	return false
+}
+
+// Failable allows an assertion to signal a fail to an external instance
+// like testing.T or testing.B.
+type Failable interface {
+	FailNow()
+}
+
+// testingFailer works together with the testing package of Go and
+// may signal the fail to it.
+type testingFailer struct {
+	mux       sync.Mutex
+	failable  Failable
+	offset    int
+	shallFail bool
+}
+
+// IncrCallstackOffset implements the failer interface.
+func (f *testingFailer) IncrCallstackOffset() func() {
+	f.mux.Lock()
+	defer f.mux.Unlock()
+	offset := f.offset
+	f.offset++
+	return func() {
+		f.mux.Lock()
+		defer f.mux.Unlock()
+		f.offset = offset
+	}
+}
+
+// Logf implements the Failer interface.
+func (f *testingFailer) Logf(format string, args ...interface{}) {
+	f.mux.Lock()
+	defer f.mux.Unlock()
+	pc, file, line, _ := runtime.Caller(f.offset)
+	_, fileName := path.Split(file)
+	funcNameParts := strings.Split(runtime.FuncForPC(pc).Name(), ".")
+	funcNamePartsIdx := len(funcNameParts) - 1
+	funcName := funcNameParts[funcNamePartsIdx]
+	prefix := fmt.Sprintf("%s:%d %s(): ", fileName, line, funcName)
+	backendPrintf(prefix+format+"\n", args...)
+}
+
+// Fail implements the Failer interface.
+func (f *testingFailer) Fail(test Test, obtained, expected interface{}, msgs ...string) bool {
+	f.mux.Lock()
+	defer f.mux.Unlock()
+	pc, file, line, _ := runtime.Caller(f.offset)
+	_, fileName := path.Split(file)
+	funcNameParts := strings.Split(runtime.FuncForPC(pc).Name(), ".")
+	funcNamePartsIdx := len(funcNameParts) - 1
+	funcName := funcNameParts[funcNamePartsIdx]
+	buffer := &bytes.Buffer{}
+	fmt.Fprintf(buffer, "--------------------------------------------------------------------------------\n")
+	if test == Fail {
+		fmt.Fprintf(buffer, "%s:%d: Assert failed!\n\n", fileName, line)
+	} else {
+		fmt.Fprintf(buffer, "%s:%d: Assert '%s' failed!\n\n", fileName, line, test)
+	}
+	fmt.Fprintf(buffer, "Function...: %s()\n", funcName)
+	switch test {
+	case True, False, Nil, NotNil, Empty, NotEmpty, Panics:
+		fmt.Fprintf(buffer, "Obtained...: %v\n", obtained)
+	case Implementor, Assignable, Unassignable:
+		fmt.Fprintf(buffer, "Obtained...: %v\n", ValueDescription(obtained))
+		fmt.Fprintf(buffer, "Expected...: %v\n", ValueDescription(expected))
+	case Contents:
+		switch typedObtained := obtained.(type) {
+		case string:
+			fmt.Fprintf(buffer, "Part.......: %s\n", typedObtained)
+			fmt.Fprintf(buffer, "Full.......: %s\n", expected)
+		default:
+			fmt.Fprintf(buffer, "Part.......: %v\n", obtained)
+			fmt.Fprintf(buffer, "Full.......: %v\n", expected)
+		}
+	case Fail:
+	default:
+		fmt.Fprintf(buffer, "Obtained...: %v\n", obtained)
+		fmt.Fprintf(buffer, "Expected...: %v\n", expected)
+	}
+	if len(msgs) > 0 {
+		fmt.Fprintf(buffer, "Description: %s\n", strings.Join(msgs, "\n             "))
+	}
+	fmt.Fprintf(buffer, "--------------------------------------------------------------------------------\n")
+	backendPrintf(buffer.String())
+	if f.shallFail {
+		f.failable.FailNow()
+	}
+	return false
+}
+
+// EOF

--- a/audit/failer.go
+++ b/audit/failer.go
@@ -19,6 +19,7 @@ import (
 	"runtime"
 	"strings"
 	"sync"
+	"time"
 )
 
 //--------------------
@@ -40,11 +41,69 @@ type Failer interface {
 	Fail(test Test, obtained, expected interface{}, msgs ...string) bool
 }
 
+// FailureDetail contains detailed information of a failure.
+type FailureDetail interface {
+	// TImestamp tells when the failure has happend.
+	Timestamp() time.Time
+
+	// Locations returns file name, line number, and
+	// function name of the failure.
+	Location() (string, int, string)
+
+	// Test tells which kind of test has failed.
+	Test() Test
+
+	// Error returns the failure as error.
+	Error() error
+
+	// Message return the optional test message.
+	Message() string
+}
+
+// failureDetail implements the FailureDetail interface.
+type failureDetail struct {
+	timestamp  time.Time
+	fileName   string
+	lineNumber int
+	funcName   string
+	test       Test
+	err        error
+	message    string
+}
+
+// TImestamp implements the FailureDetail interface.
+func (d *failureDetail) Timestamp() time.Time {
+	return d.timestamp
+}
+
+// Locations implements the FailureDetail interface.
+func (d *failureDetail) Location() (string, int, string) {
+	return d.fileName, d.lineNumber, d.funcName
+}
+
+// Test implements the FailureDetail interface.
+func (d *failureDetail) Test() Test {
+	return d.test
+}
+
+// Error implements the FailureDetail interface.
+func (d *failureDetail) Error() error {
+	return d.err
+}
+
+// Message implements the FailureDetail interface.
+func (d *failureDetail) Message() string {
+	return d.message
+}
+
 // Failures collects the collected failures
 // of a validation assertion.
 type Failures interface {
 	// HasErrors returns true, if assertion failures happened.
 	HasErrors() bool
+
+	// Details returns the collected details.
+	Details() []FailureDetail
 
 	// Errors returns the so far collected errors.
 	Errors() []error
@@ -52,6 +111,10 @@ type Failures interface {
 	// Error returns the collected errors as one error.
 	Error() error
 }
+
+//--------------------
+// PANIC FAILER
+//--------------------
 
 // panicFailer reacts with a panic.
 type panicFailer struct{}
@@ -72,11 +135,22 @@ func (f panicFailer) Fail(test Test, obtained, expected interface{}, msgs ...str
 	panic(failString(test, obex, msgs...))
 }
 
+// NewPanicAssertion creates a new Assertion instance which panics if a test fails.
+func NewPanicAssertion() Assertion {
+	return NewAssertion(&panicFailer{})
+}
+
+//--------------------
+// VALIDATION FAILER
+//--------------------
+
 // validationFailer collects validation errors, e.g. when
 // validating form input data.
 type validationFailer struct {
-	mux  sync.Mutex
-	errs []error
+	mux     sync.Mutex
+	offset  int
+	details []FailureDetail
+	errs    []error
 }
 
 // HasErrors implements the Failures interface.
@@ -84,6 +158,13 @@ func (f *validationFailer) HasErrors() bool {
 	f.mux.Lock()
 	defer f.mux.Unlock()
 	return len(f.errs) > 0
+}
+
+// Details implements the Failures interface.
+func (f *validationFailer) Details() []FailureDetail {
+	f.mux.Lock()
+	defer f.mux.Unlock()
+	return f.details
 }
 
 // Errors implements the Failures interface.
@@ -106,24 +187,70 @@ func (f *validationFailer) Error() error {
 
 // IncrCallstackOffset implements the Failer interface.
 func (f *validationFailer) IncrCallstackOffset() func() {
-	return func() {}
+	f.mux.Lock()
+	defer f.mux.Unlock()
+	offset := f.offset
+	f.offset++
+	return func() {
+		f.mux.Lock()
+		defer f.mux.Unlock()
+		f.offset = offset
+	}
 }
 
 // Logf implements the Failer interface.
 func (f *validationFailer) Logf(format string, args ...interface{}) {
 	f.mux.Lock()
 	defer f.mux.Unlock()
-	backendPrintf(format+"\n", args...)
+	pc, file, line, _ := runtime.Caller(f.offset)
+	_, fileName := path.Split(file)
+	funcNameParts := strings.Split(runtime.FuncForPC(pc).Name(), ".")
+	funcNamePartsIdx := len(funcNameParts) - 1
+	funcName := funcNameParts[funcNamePartsIdx]
+	prefix := fmt.Sprintf("%s:%d %s(): ", fileName, line, funcName)
+	backendPrintf(prefix+format+"\n", args...)
 }
 
 // Fail implements the Failer interface.
 func (f *validationFailer) Fail(test Test, obtained, expected interface{}, msgs ...string) bool {
 	f.mux.Lock()
 	defer f.mux.Unlock()
+	pc, file, line, _ := runtime.Caller(f.offset)
+	_, fileName := path.Split(file)
+	funcNameParts := strings.Split(runtime.FuncForPC(pc).Name(), ".")
+	funcNamePartsIdx := len(funcNameParts) - 1
+	funcName := funcNameParts[funcNamePartsIdx]
 	obex := obexString(test, obtained, expected)
-	f.errs = append(f.errs, errors.New(failString(test, obex, msgs...)))
+	err := errors.New(failString(test, obex, msgs...))
+	detail := &failureDetail{
+		timestamp:  time.Now(),
+		fileName:   fileName,
+		lineNumber: line,
+		funcName:   funcName,
+		test:       test,
+		err:        err,
+		message:    strings.Join(msgs, " "),
+	}
+	f.details = append(f.details, detail)
+	f.errs = append(f.errs, err)
 	return false
 }
+
+// NewValidationAssertion creates a new Assertion instance which collections
+// validation failures. The returned Failures instance allows to test an access
+// them.
+func NewValidationAssertion() (Assertion, Failures) {
+	vf := &validationFailer{
+		offset:  2,
+		details: []FailureDetail{},
+		errs:    []error{},
+	}
+	return NewAssertion(vf), vf
+}
+
+//--------------------
+// TESTING FAILER
+//--------------------
 
 // Failable allows an assertion to signal a fail to an external instance
 // like testing.T or testing.B.
@@ -212,6 +339,17 @@ func (f *testingFailer) Fail(test Test, obtained, expected interface{}, msgs ...
 		f.failable.FailNow()
 	}
 	return false
+}
+
+// NewTestingAssertion creates a new Assertion instance for use with the testing
+// package. The *testing.T has to be passed as failable, the first argument.
+// shallFail controls if a failing assertion also lets fail the Go test.
+func NewTestingAssertion(f Failable, shallFail bool) Assertion {
+	return NewAssertion(&testingFailer{
+		failable:  f,
+		offset:    2,
+		shallFail: shallFail,
+	})
 }
 
 // EOF

--- a/audit/printer.go
+++ b/audit/printer.go
@@ -1,0 +1,116 @@
+// Tideland Go Library - Audit
+//
+// Copyright (C) 2012-2017 Frank Mueller / Tideland / Oldenburg / Germany
+//
+// All rights reserved. Use of this source code is governed
+// by the new BSD license.
+
+package audit
+
+//--------------------
+// IMPORTS
+//--------------------
+
+import (
+	"fmt"
+	"reflect"
+	"sync"
+)
+
+//--------------------
+// PRINTER
+//--------------------
+
+var testNames = []string{
+	Invalid:      "invalid",
+	True:         "true",
+	False:        "false",
+	Nil:          "nil",
+	NotNil:       "not nil",
+	Equal:        "equal",
+	Different:    "different",
+	Contents:     "contents",
+	About:        "about",
+	Range:        "range",
+	Substring:    "substring",
+	Case:         "case",
+	Match:        "match",
+	ErrorMatch:   "error match",
+	Implementor:  "implementor",
+	Assignable:   "assignable",
+	Unassignable: "unassignable",
+	Empty:        "empty",
+	NotEmpty:     "not empty",
+	Length:       "length",
+	Panics:       "panics",
+	PathExists:   "path exists",
+	Wait:         "wait",
+	Retry:        "retry",
+	Fail:         "fail",
+}
+
+func (t Test) String() string {
+	if int(t) < len(testNames) {
+		return testNames[t]
+	}
+	return "invalid"
+}
+
+// ValueDescription returns a description of a value as string.
+func ValueDescription(value interface{}) string {
+	rvalue := reflect.ValueOf(value)
+	kind := rvalue.Kind()
+	switch kind {
+	case reflect.Array, reflect.Chan, reflect.Map, reflect.Slice:
+		return kind.String() + " of " + rvalue.Type().Elem().String()
+	case reflect.Func:
+		return kind.String() + " " + rvalue.Type().Name() + "()"
+	case reflect.Interface, reflect.Struct:
+		return kind.String() + " " + rvalue.Type().Name()
+	case reflect.Ptr:
+		return kind.String() + " to " + rvalue.Type().Elem().String()
+	}
+	// Default.
+	return kind.String()
+}
+
+// Printer allows to switch between different outputs.
+type Printer interface {
+	// Printf prints a formatted information.
+	Printf(format string, args ...interface{})
+}
+
+// printerBackend is the globally printer used during
+// the assertions.
+var (
+	printerBackend Printer = &fmtPrinter{}
+	mux            sync.Mutex
+)
+
+// fmtPrinter uses the standard fmt package for printing.
+type fmtPrinter struct{}
+
+// Printf implements the Printer interface.
+func (p *fmtPrinter) Printf(format string, args ...interface{}) {
+	fmt.Printf(format, args...)
+}
+
+// SetPrinter sets a new global printer and returns the
+// current one.
+func SetPrinter(p Printer) Printer {
+	mux.Lock()
+	defer mux.Unlock()
+	cp := printerBackend
+	printerBackend = p
+	return cp
+}
+
+// backendPrintf uses the printer backend for output. It is used
+// in the types below.
+func backendPrintf(format string, args ...interface{}) {
+	mux.Lock()
+	defer mux.Unlock()
+	printerBackend.Printf(format, args...)
+}
+
+// EOF

--- a/audit/tester.go
+++ b/audit/tester.go
@@ -1,0 +1,246 @@
+// Tideland Go Library - Audit
+//
+// Copyright (C) 2012-2017 Frank Mueller / Tideland / Oldenburg / Germany
+//
+// All rights reserved. Use of this source code is governed
+// by the new BSD license.
+
+package audit
+
+//--------------------
+// IMPORTS
+//--------------------
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"os"
+	"reflect"
+	"regexp"
+	"strings"
+)
+
+//--------------------
+// TESTER
+//--------------------
+
+// Tester is a helper which can be used in own Assertion implementations.
+type Tester struct{}
+
+// IsTrue checks if obtained is true.
+func (t Tester) IsTrue(obtained bool) bool {
+	return obtained == true
+}
+
+// IsNil checks if obtained is nil in a safe way.
+func (t Tester) IsNil(obtained interface{}) bool {
+	if obtained == nil {
+		// Standard test.
+		return true
+	}
+	// Some types have to be tested via reflection.
+	value := reflect.ValueOf(obtained)
+	kind := value.Kind()
+	switch kind {
+	case reflect.Chan, reflect.Func, reflect.Interface, reflect.Map, reflect.Ptr, reflect.Slice:
+		return value.IsNil()
+	}
+	return false
+}
+
+// IsEqual checks if obtained and expected are equal.
+func (t Tester) IsEqual(obtained, expected interface{}) bool {
+	return reflect.DeepEqual(obtained, expected)
+}
+
+// IsAbout checks if obtained and expected are to a given extent almost equal.
+func (t Tester) IsAbout(obtained, expected, extent float64) bool {
+	if extent < 0.0 {
+		extent = extent * (-1)
+	}
+	low := expected - extent
+	high := expected + extent
+	return low <= obtained && obtained <= high
+}
+
+// IsInRange checks, if obtained is inside the given range. In case of a
+// slice, array, or map it will check agains the length.
+func (t Tester) IsInRange(obtained, low, high interface{}) (bool, error) {
+	// First standard types.
+	switch o := obtained.(type) {
+	case byte:
+		l, lok := low.(byte)
+		h, hok := high.(byte)
+		if !lok && !hok {
+			return false, errors.New("low and/or high are no byte")
+		}
+		return l <= o && o <= h, nil
+	case int:
+		l, lok := low.(int)
+		h, hok := high.(int)
+		if !lok && !hok {
+			return false, errors.New("low and/or high are no int")
+		}
+		return l <= o && o <= h, nil
+	case float64:
+		l, lok := low.(float64)
+		h, hok := high.(float64)
+		if !lok && !hok {
+			return false, errors.New("low and/or high are no float64")
+		}
+		return l <= o && o <= h, nil
+	case rune:
+		l, lok := low.(rune)
+		h, hok := high.(rune)
+		if !lok && !hok {
+			return false, errors.New("low and/or high are no rune")
+		}
+		return l <= o && o <= h, nil
+	case string:
+		l, lok := low.(string)
+		h, hok := high.(string)
+		if !lok && !hok {
+			return false, errors.New("low and/or high are no string")
+		}
+		return l <= o && o <= h, nil
+	}
+	// Now check the collection types.
+	ol, err := t.Len(obtained)
+	if err != nil {
+		return false, errors.New("no valid type with a length")
+	}
+	l, lok := low.(int)
+	h, hok := high.(int)
+	if !lok && !hok {
+		return false, errors.New("low and/or high are no int")
+	}
+	return l <= ol && ol <= h, nil
+}
+
+// Contains checks if the part type is matching to the full type and
+// if the full data containes the part data.
+func (t Tester) Contains(part, full interface{}) (bool, error) {
+	switch fullValue := full.(type) {
+	case string:
+		// Content of a string.
+		switch partValue := part.(type) {
+		case string:
+			return strings.Contains(fullValue, partValue), nil
+		case []byte:
+			return strings.Contains(fullValue, string(partValue)), nil
+		default:
+			partString := fmt.Sprintf("%v", partValue)
+			return strings.Contains(fullValue, partString), nil
+		}
+	case []byte:
+		// Content of a byte slice.
+		switch partValue := part.(type) {
+		case string:
+			return bytes.Contains(fullValue, []byte(partValue)), nil
+		case []byte:
+			return bytes.Contains(fullValue, partValue), nil
+		default:
+			partBytes := []byte(fmt.Sprintf("%v", partValue))
+			return bytes.Contains(fullValue, partBytes), nil
+		}
+	default:
+		// Content of any array or slice, use reflection.
+		value := reflect.ValueOf(full)
+		kind := value.Kind()
+		if kind == reflect.Array || kind == reflect.Slice {
+			length := value.Len()
+			for i := 0; i < length; i++ {
+				current := value.Index(i)
+				if reflect.DeepEqual(part, current.Interface()) {
+					return true, nil
+				}
+			}
+			return false, nil
+		}
+	}
+	return false, errors.New("full value is no string, array, or slice")
+}
+
+// IsSubstring checks if obtained is a substring of the full string.
+func (t Tester) IsSubstring(obtained, full string) bool {
+	return strings.Contains(full, obtained)
+}
+
+// IsCase checks if the obtained string is uppercase or lowercase.
+func (t Tester) IsCase(obtained string, upperCase bool) bool {
+	if upperCase {
+		return obtained == strings.ToUpper(obtained)
+	}
+	return obtained == strings.ToLower(obtained)
+}
+
+// IsMatching checks if the obtained string matches a regular expression.
+func (t Tester) IsMatching(obtained, regex string) (bool, error) {
+	return regexp.MatchString("^"+regex+"$", obtained)
+}
+
+// IsImplementor checks if obtained implements the expected interface variable pointer.
+func (t Tester) IsImplementor(obtained, expected interface{}) (bool, error) {
+	obtainedValue := reflect.ValueOf(obtained)
+	expectedValue := reflect.ValueOf(expected)
+	if !obtainedValue.IsValid() {
+		return false, fmt.Errorf("obtained value is invalid: %v", obtained)
+	}
+	if !expectedValue.IsValid() || expectedValue.Kind() != reflect.Ptr || expectedValue.Elem().Kind() != reflect.Interface {
+		return false, fmt.Errorf("expected value is no interface variable pointer: %v", expected)
+	}
+	return obtainedValue.Type().Implements(expectedValue.Elem().Type()), nil
+}
+
+// IsAssignable checks if the types of obtained and expected are assignable.
+func (t Tester) IsAssignable(obtained, expected interface{}) bool {
+	obtainedValue := reflect.ValueOf(obtained)
+	expectedValue := reflect.ValueOf(expected)
+	return obtainedValue.Type().AssignableTo(expectedValue.Type())
+}
+
+// Length checks the len of the obtained string, array, slice, map or channel.
+func (t Tester) Len(obtained interface{}) (int, error) {
+	// Check using the lenable interface.
+	if l, ok := obtained.(lenable); ok {
+		return l.Len(), nil
+	}
+	// Check the standard types.
+	obtainedValue := reflect.ValueOf(obtained)
+	obtainedKind := obtainedValue.Kind()
+	switch obtainedKind {
+	case reflect.Array, reflect.Chan, reflect.Map, reflect.Slice, reflect.String:
+		return obtainedValue.Len(), nil
+	default:
+		descr := ValueDescription(obtained)
+		return 0, fmt.Errorf("obtained %s is no array, chan, map, slice, string or understands Len()", descr)
+	}
+}
+
+// HasPanic checks if the passed function panics.
+func (t Tester) HasPanic(pf func()) (ok bool) {
+	defer func() {
+		if r := recover(); r != nil {
+			// Panic, that's ok!
+			ok = true
+		}
+	}()
+	pf()
+	return false
+}
+
+// IsValidPath checks if the given directory or
+// file path exists.
+func (t Tester) IsValidPath(path string) (bool, error) {
+	_, err := os.Stat(path)
+	if err == nil {
+		return true, nil
+	}
+	if os.IsNotExist(err) {
+		return false, nil
+	}
+	return true, err
+}
+
+// EOF

--- a/audit/tester.go
+++ b/audit/tester.go
@@ -19,6 +19,7 @@ import (
 	"reflect"
 	"regexp"
 	"strings"
+	"time"
 )
 
 //--------------------
@@ -64,8 +65,7 @@ func (t Tester) IsAbout(obtained, expected, extent float64) bool {
 	return low <= obtained && obtained <= high
 }
 
-// IsInRange checks, if obtained is inside the given range. In case of a
-// slice, array, or map it will check agains the length.
+// IsInRange checks for range assertions
 func (t Tester) IsInRange(obtained, low, high interface{}) (bool, error) {
 	// First standard types.
 	switch o := obtained.(type) {
@@ -102,6 +102,21 @@ func (t Tester) IsInRange(obtained, low, high interface{}) (bool, error) {
 		h, hok := high.(string)
 		if !lok && !hok {
 			return false, errors.New("low and/or high are no string")
+		}
+		return l <= o && o <= h, nil
+	case time.Time:
+		l, lok := low.(time.Time)
+		h, hok := high.(time.Time)
+		if !lok && !hok {
+			return false, errors.New("low and/or high are no time")
+		}
+		return (l.Equal(o) || l.Before(o)) &&
+			(h.After(o) || h.Equal(o)), nil
+	case time.Duration:
+		l, lok := low.(time.Duration)
+		h, hok := high.(time.Duration)
+		if !lok && !hok {
+			return false, errors.New("low and/or high are no duration")
 		}
 		return l <= o && o <= h, nil
 	}

--- a/cache/cache_test.go
+++ b/cache/cache_test.go
@@ -33,4 +33,76 @@ func TestNoLoader(t *testing.T) {
 	assert.True(errors.IsError(err, cache.ErrNoLoader))
 }
 
+// TestLoader tests the creation of a cache with
+// a loader.
+func TestLoader(t *testing.T) {
+	assert := audit.NewTestingAssertion(t, true)
+
+	c, err := cache.New(cache.ID("loader"), cache.Loader(testCacheableLoader))
+	assert.Nil(err)
+	assert.NotNil(c)
+}
+
+//--------------------
+// HELPERS
+//--------------------
+
+const (
+	errLoading = iota + 1
+	errIsObtained
+	errDoubleDiscarding
+)
+
+var errorMessages = errors.Messages{
+	errLoading:          "error during loading",
+	errIsObtained:       "error during check if '%s' is obtained",
+	errDoubleDiscarding: "cacheable '%s' double discarded",
+}
+
+// testCacheableLoader loads the testCacheable.
+func testCacheableLoader(id string) (cache.Cacheable, error) {
+	if id == "error-during-loading" {
+		return nil, errors.New(errLoading, errorMessages)
+	}
+	return &testCacheable{
+		id:        id,
+		retrieved: 1,
+		discarded: false,
+	}, nil
+}
+
+// testCacheable implements Cacheable for testing.
+type testCacheable struct {
+	id        string
+	retrieved int
+	discarded bool
+}
+
+func (tc *testCacheable) ID() string {
+	return tc.id
+}
+
+// IsOutdated checks if their's a newer version of the Cacheable.
+func (tc *testCacheable) IsOutdated() (bool, error) {
+	switch tc.id {
+	case "error-during-check":
+		return false, errors.New(errIsObtained, errorMessages, tc.id)
+	case "is-outdated":
+		tc.retrieved++
+		if tc.retrieved == 5 {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+// Discard tells the Cacheable to clean up itself.
+func (tc *testCacheable) Discard() error {
+	if tc.discarded {
+		return errors.New(errDoubleDiscarding, errorMessages, tc.id)
+	}
+	tc.discarded = true
+	return nil
+}
+
 // EOF

--- a/cache/cache_test.go
+++ b/cache/cache_test.go
@@ -1,6 +1,6 @@
-// Tideland Go Library - Cache - Unit Test
+// Tideland Go Library - Cache - Unit Tests
 //
-// Copyright (C) 2009-2015 Frank Mueller / Tideland / Oldenburg / Germany
+// Copyright (C) 2009-2017 Frank Mueller / Tideland / Oldenburg / Germany
 //
 // All rights reserved. Use of this source code is governed
 // by the new BSD license.
@@ -12,80 +12,25 @@ package cache_test
 //--------------------
 
 import (
-	"fmt"
 	"testing"
-	"time"
 
 	"github.com/tideland/golib/audit"
 	"github.com/tideland/golib/cache"
+	"github.com/tideland/golib/errors"
 )
 
 //--------------------
 // TESTS
 //--------------------
 
-// Test the normal retrieving without errors.
-func TestNormalRetrieve(t *testing.T) {
+// TestNoLoader tests the creation of a cache without
+// a loader. Must lead to an error.
+func TestNoLoader(t *testing.T) {
 	assert := audit.NewTestingAssertion(t, true)
 
-	// Environment.
-	ctr := 0
-	count := func() (interface{}, error) {
-		ctr++
-		return ctr, nil
-	}
-	cv := cache.NewCachedValue(count, 25*time.Millisecond)
-	defer cv.Remove()
-	retrieve := func() int { v, _ := cv.Value(); return v.(int) }
-
-	// Asserts.
-	assert.Equal(retrieve(), 1)
-	assert.Equal(retrieve(), 1)
-	time.Sleep(100 * time.Millisecond)
-	assert.Equal(retrieve(), 2)
-	time.Sleep(100 * time.Millisecond)
-	assert.Equal(retrieve(), 3)
-	assert.Equal(retrieve(), 3)
-}
-
-// Test the retrieving with an error.
-func TestRetrieveError(t *testing.T) {
-	assert := audit.NewTestingAssertion(t, true)
-
-	// Environment.
-	ctr := 0
-	efunc := func() (interface{}, error) {
-		ctr++
-		return nil, fmt.Errorf("ouch %d", ctr)
-	}
-	cv := cache.NewCachedValue(efunc, 25*time.Millisecond)
-	defer cv.Remove()
-	retrieve := func() error { _, err := cv.Value(); return err }
-
-	// Asserts.
-	assert.ErrorMatch(retrieve(), "ouch 1")
-	assert.ErrorMatch(retrieve(), "ouch 2")
-	assert.ErrorMatch(retrieve(), "ouch 3")
-}
-
-// Test the retrieving with a panic.
-func TestRetrievePanic(t *testing.T) {
-	assert := audit.NewTestingAssertion(t, true)
-
-	// Environment.
-	ctr := 0
-	pfunc := func() (interface{}, error) {
-		ctr++
-		panic(fmt.Sprintf("ouch %d", ctr))
-	}
-	cv := cache.NewCachedValue(pfunc, 25*time.Millisecond)
-	defer cv.Remove()
-	retrieve := func() error { _, err := cv.Value(); return err }
-
-	// Asserts.
-	assert.ErrorMatch(retrieve(), `.* cannot retrieve cached value: ouch 1`)
-	assert.ErrorMatch(retrieve(), `.* cannot retrieve cached value: ouch 2`)
-	assert.ErrorMatch(retrieve(), `.* cannot retrieve cached value: ouch 3`)
+	c, err := cache.New()
+	assert.Nil(c)
+	assert.True(errors.IsError(err, cache.ErrNoLoader))
 }
 
 // EOF

--- a/cache/cache_test.go
+++ b/cache/cache_test.go
@@ -13,6 +13,7 @@ package cache_test
 
 import (
 	"testing"
+	"time"
 
 	"github.com/tideland/golib/audit"
 	"github.com/tideland/golib/cache"
@@ -41,6 +42,74 @@ func TestLoader(t *testing.T) {
 	c, err := cache.New(cache.ID("loader"), cache.Loader(testCacheableLoader))
 	assert.Nil(err)
 	assert.NotNil(c)
+	err = c.Stop()
+	assert.Nil(err)
+}
+
+// TestLoading tests the load method of a Cache.
+func TestLoading(t *testing.T) {
+	assert := audit.NewTestingAssertion(t, true)
+
+	c, err := cache.New(cache.ID("loading"), cache.Loader(testCacheableLoader))
+	assert.Nil(err)
+	defer c.Stop()
+
+	cacheable, err := c.Load("error-during-loading", time.Second)
+	assert.Nil(cacheable)
+	assert.ErrorMatch(err, ".*error during loading.*")
+
+	cacheable, err = c.Load("timeout", 10*time.Millisecond)
+	assert.Nil(cacheable)
+	assert.ErrorMatch(err, ".*timeout.*")
+
+	now := time.Now()
+	cacheable, err = c.Load("valid-cacheable", time.Second)
+	first := time.Now().Sub(now)
+	assert.Nil(err)
+	assert.Equal(cacheable.ID(), "valid-cacheable")
+	now = time.Now()
+	cacheable, err = c.Load("valid-cacheable", time.Second)
+	second := time.Now().Sub(now)
+	assert.Nil(err)
+	assert.Equal(cacheable.ID(), "valid-cacheable")
+	assert.True(second < first)
+}
+
+// TestOutdating tests the outdating of Cacheables.
+func TestOutdating(t *testing.T) {
+	assert := audit.NewTestingAssertion(t, true)
+
+	c, err := cache.New(cache.ID("outdating"), cache.Loader(testCacheableLoader))
+	assert.Nil(err)
+	defer c.Stop()
+
+	// Test if outdate check fails.
+	cacheable, err := c.Load("error-during-check", time.Second)
+	assert.Nil(err)
+	assert.Equal(cacheable.ID(), "error-during-check")
+
+	cacheable, err = c.Load("error-during-check", time.Second)
+	assert.Nil(cacheable)
+	assert.ErrorMatch(err, ".*error during check if 'error-during-check' is obtained.*")
+
+	// Test reload when outdated.
+	for i := 1; i < 6; i++ {
+		_, err := c.Load("is-outdated", time.Second)
+		assert.Nil(err)
+		assert.Equal(loaded["is-outdated"], i)
+	}
+	_, err = c.Load("is-outdated", time.Second)
+	assert.Nil(err)
+	assert.Equal(loaded["is-outdated"], 1)
+
+	// Test error during reload.
+	for i := 1; i < 6; i++ {
+		_, err := c.Load("error-during-reloading", time.Second)
+		assert.Nil(err)
+		assert.Equal(loaded["error-during-reloading"], i)
+	}
+	_, err = c.Load("error-during-reloading", time.Second)
+	assert.ErrorMatch(err, ".*error during loading.*")
 }
 
 //--------------------
@@ -59,14 +128,25 @@ var errorMessages = errors.Messages{
 	errDoubleDiscarding: "cacheable '%s' double discarded",
 }
 
+var loaded = map[string]int{}
+
+var reloaded = map[string]bool{}
+
 // testCacheableLoader loads the testCacheable.
 func testCacheableLoader(id string) (cache.Cacheable, error) {
-	if id == "error-during-loading" {
+	switch id {
+	case "error-during-loading":
+		return nil, errors.New(errLoading, errorMessages)
+	case "timeout":
+		time.Sleep(50 * time.Millisecond)
+	}
+	time.Sleep(50 * time.Millisecond)
+	loaded[id] = 1
+	if id == "error-during-reloading" && reloaded[id] {
 		return nil, errors.New(errLoading, errorMessages)
 	}
 	return &testCacheable{
 		id:        id,
-		retrieved: 1,
 		discarded: false,
 	}, nil
 }
@@ -74,7 +154,6 @@ func testCacheableLoader(id string) (cache.Cacheable, error) {
 // testCacheable implements Cacheable for testing.
 type testCacheable struct {
 	id        string
-	retrieved int
 	discarded bool
 }
 
@@ -88,8 +167,9 @@ func (tc *testCacheable) IsOutdated() (bool, error) {
 	case "error-during-check":
 		return false, errors.New(errIsObtained, errorMessages, tc.id)
 	case "is-outdated":
-		tc.retrieved++
-		if tc.retrieved == 5 {
+		loaded[tc.id]++
+		if loaded[tc.id] == 5 {
+			reloaded[tc.id] = true
 			return true, nil
 		}
 	}

--- a/cache/doc.go
+++ b/cache/doc.go
@@ -1,13 +1,13 @@
 // Tideland Go Library - Cache
 //
-// Copyright (C) 2009-2015 Frank Mueller / Tideland / Oldenburg / Germany
+// Copyright (C) 2009-2017 Frank Mueller / Tideland / Oldenburg / Germany
 //
 // All rights reserved. Use of this source code is governed
 // by the new BSD license.
 
-// The Tideland Go Library cache package  provides a caching for individual
-// lazy loaded values. The retrieval function and the timeout have to be
-// specified.
+// Package cache lazily loads information on demand and caches them. In
+// case of too many instances older ones will be removed. Also those
+// existing longer than a defined duration will be removed again.
 package cache
 
 // EOF

--- a/cache/doc.go
+++ b/cache/doc.go
@@ -5,9 +5,11 @@
 // All rights reserved. Use of this source code is governed
 // by the new BSD license.
 
-// Package cache lazily loads information on demand and caches them. In
-// case of too many instances older ones will be removed. Also those
-// existing longer than a defined duration will be removed again.
+// Package cache lazily loads information on demand and caches them.
+// The data inside a cache has to implement the Cacheable interface
+// which also contains methods for checking, if the information is
+// outdated, and for discarding the cached instance. It is loaded
+// by a user defined CacheableLoader function.
 package cache
 
 // EOF

--- a/cache/errors.go
+++ b/cache/errors.go
@@ -27,17 +27,19 @@ const (
 	ErrLoading
 	ErrCheckOutdated
 	ErrDiscard
+	ErrDiscardedWhileLoading
 	ErrTimeout
 )
 
 var errorMessages = errors.Messages{
-	ErrSettingOptions: "cannot set option",
-	ErrIllegalCache:   "illegal cache type for option",
-	ErrNoLoader:       "no loader configured",
-	ErrLoading:        "cannot load cacheable '%s'",
-	ErrCheckOutdated:  "cannot check if '%s' is outdated",
-	ErrDiscard:        "cannot discard '%s'",
-	ErrTimeout:        "timeout",
+	ErrSettingOptions:        "cannot set option",
+	ErrIllegalCache:          "illegal cache type for option",
+	ErrNoLoader:              "no loader configured",
+	ErrLoading:               "cannot load cacheable '%s'",
+	ErrCheckOutdated:         "cannot check if '%s' is outdated",
+	ErrDiscard:               "cannot discard '%s'",
+	ErrDiscardedWhileLoading: "cacheable '%s' discarded while loading",
+	ErrTimeout:               "timeout",
 }
 
 // EOF

--- a/cache/errors.go
+++ b/cache/errors.go
@@ -1,0 +1,37 @@
+// Tideland Go Library - Cache
+//
+// Copyright (C) 2009-2017 Frank Mueller / Tideland / Oldenburg / Germany
+//
+// All rights reserved. Use of this source code is governed
+// by the new BSD license.
+
+package cache
+
+//--------------------
+// IMPORTS
+//--------------------
+
+import (
+	"github.com/tideland/golib/errors"
+)
+
+//--------------------
+// CONSTANTS
+//--------------------
+
+// Errors of the Cache.
+const (
+	ErrSettingOptions = iota + 1
+	ErrIllegalCache
+	ErrNoLoader
+	ErrTimeout
+)
+
+var errorMessages = errors.Messages{
+	ErrSettingOptions: "cannot set option",
+	ErrIllegalCache:   "illegal cache type for option",
+	ErrNoLoader:       "no loader configured",
+	ErrTimeout:        "timeout",
+}
+
+// EOF

--- a/cache/errors.go
+++ b/cache/errors.go
@@ -39,7 +39,7 @@ var errorMessages = errors.Messages{
 	ErrCheckOutdated:         "cannot check if '%s' is outdated",
 	ErrDiscard:               "cannot discard '%s'",
 	ErrDiscardedWhileLoading: "cacheable '%s' discarded while loading",
-	ErrTimeout:               "timeout",
+	ErrTimeout:               "timeout while %s",
 }
 
 // EOF

--- a/cache/errors.go
+++ b/cache/errors.go
@@ -24,6 +24,9 @@ const (
 	ErrSettingOptions = iota + 1
 	ErrIllegalCache
 	ErrNoLoader
+	ErrLoading
+	ErrCheckOutdated
+	ErrDiscard
 	ErrTimeout
 )
 
@@ -31,6 +34,9 @@ var errorMessages = errors.Messages{
 	ErrSettingOptions: "cannot set option",
 	ErrIllegalCache:   "illegal cache type for option",
 	ErrNoLoader:       "no loader configured",
+	ErrLoading:        "cannot load cacheable '%s'",
+	ErrCheckOutdated:  "cannot check if '%s' is outdated",
+	ErrDiscard:        "cannot discard '%s'",
 	ErrTimeout:        "timeout",
 }
 

--- a/cache/errors.go
+++ b/cache/errors.go
@@ -29,6 +29,8 @@ const (
 	ErrDiscard
 	ErrDiscardedWhileLoading
 	ErrTimeout
+	ErrFileOpening
+	ErrFileChecking
 )
 
 var errorMessages = errors.Messages{
@@ -40,6 +42,8 @@ var errorMessages = errors.Messages{
 	ErrDiscard:               "cannot discard '%s'",
 	ErrDiscardedWhileLoading: "cacheable '%s' discarded while loading",
 	ErrTimeout:               "timeout while %s",
+	ErrFileOpening:           "cannot open file '%s'",
+	ErrFileChecking:          "cannot check file '%s'",
 }
 
 // EOF

--- a/cache/errors.go
+++ b/cache/errors.go
@@ -29,7 +29,8 @@ const (
 	ErrDiscard
 	ErrDiscardedWhileLoading
 	ErrTimeout
-	ErrFileOpening
+	ErrFileLoading
+	ErrFileSize
 	ErrFileChecking
 )
 
@@ -42,7 +43,8 @@ var errorMessages = errors.Messages{
 	ErrDiscard:               "cannot discard '%s'",
 	ErrDiscardedWhileLoading: "cacheable '%s' discarded while loading",
 	ErrTimeout:               "timeout while %s",
-	ErrFileOpening:           "cannot open file '%s'",
+	ErrFileLoading:           "cannot load file '%s'",
+	ErrFileSize:              "file '%s' is too large",
 	ErrFileChecking:          "cannot check file '%s'",
 }
 

--- a/cache/loader.go
+++ b/cache/loader.go
@@ -18,6 +18,8 @@ import (
 	"path/filepath"
 	"time"
 
+	"bytes"
+
 	"github.com/tideland/golib/errors"
 )
 
@@ -29,14 +31,33 @@ import (
 type FileCacheable interface {
 	Cacheable
 
-	io.Reader
+	// ReadCloser returns the io.ReadCloser for the
+	// cached file or the file itself if it's too large.
+	ReadCloser() (io.ReadCloser, error)
+}
+
+// fileBuffer encapsulates a bytes.Buffer as io.ReadCloser.
+type fileBuffer struct {
+	b *bytes.Buffer
+}
+
+// Read implements the io.ReadCloser interface.
+func (fb *fileBuffer) Read(p []byte) (int, error) {
+	return fb.b.Read(p)
+}
+
+// Close implements the io.ReadCloser interface.
+func (fb *fileBuffer) Close() error {
+	return nil
 }
 
 // fileCacheable implements the FileCacheable interface.
 type fileCacheable struct {
-	name    string
-	modTime time.Time
-	data    []byte
+	name     string
+	fullname string
+	tooLarge bool
+	modTime  time.Time
+	data     []byte
 }
 
 // ID implements the Cacheable interface.
@@ -46,7 +67,7 @@ func (c *fileCacheable) ID() string {
 
 // IsOutdated implements the Cacheable interface.
 func (c *fileCacheable) IsOutdated() (bool, error) {
-	fi, err := os.Stat(c.name)
+	fi, err := os.Stat(c.fullname)
 	if err != nil {
 		return false, errors.Annotate(err, ErrFileChecking, errorMessages)
 	}
@@ -61,10 +82,19 @@ func (c *fileCacheable) Discard() error {
 	return nil
 }
 
-// Read implements the Reader interface.
-func (c *fileCacheable) Read(p []byte) (int, error) {
-	n := copy(p, c.data)
-	return n, nil
+// ReadCloser implements the FileCacheable interface.
+func (c *fileCacheable) ReadCloser() (io.ReadCloser, error) {
+	// Check if the file has to be returned directly because
+	// it is too large.
+	if c.tooLarge {
+		f, err := os.Open(c.fullname)
+		if err != nil {
+			return nil, errors.Annotate(err, ErrFileLoading, errorMessages, c.name)
+		}
+		return f, nil
+	}
+	// It's a cached buffer, so return this.
+	return &fileBuffer{bytes.NewBuffer(c.data)}, nil
 }
 
 // NewFileLoader returns a CacheableLoader for files. It
@@ -77,16 +107,22 @@ func NewFileLoader(root string, maxSize int64) CacheableLoader {
 			return nil, errors.Annotate(err, ErrFileLoading, errorMessages, name)
 		}
 		if fi.Size() > maxSize {
-			return nil, errors.New(ErrFileSize, errorMessages, name)
+			return &fileCacheable{
+				name:     name,
+				fullname: fn,
+				tooLarge: true,
+				modTime:  fi.ModTime(),
+			}, nil
 		}
 		data, err := ioutil.ReadFile(fn)
 		if err != nil {
 			return nil, errors.Annotate(err, ErrFileLoading, errorMessages, name)
 		}
 		return &fileCacheable{
-			name:    name,
-			modTime: fi.ModTime(),
-			data:    data,
+			name:     name,
+			fullname: fn,
+			modTime:  fi.ModTime(),
+			data:     data,
 		}, nil
 	}
 }

--- a/cache/loader.go
+++ b/cache/loader.go
@@ -13,10 +13,9 @@ package cache
 
 import (
 	"io"
+	"io/ioutil"
 	"os"
 	"time"
-
-	"io/ioutil"
 
 	"github.com/tideland/golib/errors"
 )

--- a/cache/loader.go
+++ b/cache/loader.go
@@ -1,0 +1,18 @@
+// Tideland Go Library - Cache - Loader
+//
+// Copyright (C) 2009-2017 Frank Mueller / Tideland / Oldenburg / Germany
+//
+// All rights reserved. Use of this source code is governed
+// by the new BSD license.
+
+package cache
+
+//--------------------
+// IMPORTS
+//--------------------
+
+//--------------------
+// LOADER
+//--------------------
+
+// EOF

--- a/cache/loader.go
+++ b/cache/loader.go
@@ -15,6 +15,7 @@ import (
 	"io"
 	"io/ioutil"
 	"os"
+	"path/filepath"
 	"time"
 
 	"github.com/tideland/golib/errors"
@@ -70,7 +71,7 @@ func (c *fileCacheable) Read(p []byte) (int, error) {
 // starts at the given root directory.
 func NewFileLoader(root string, maxSize int64) CacheableLoader {
 	return func(name string) (Cacheable, error) {
-		fn := root + name
+		fn := filepath.Join(root, name)
 		fi, err := os.Stat(fn)
 		if err != nil {
 			return nil, errors.Annotate(err, ErrFileLoading, errorMessages, name)

--- a/cache/loader_test.go
+++ b/cache/loader_test.go
@@ -17,8 +17,11 @@ import (
 
 	"path/filepath"
 
+	"time"
+
 	"github.com/tideland/golib/audit"
 	"github.com/tideland/golib/cache"
+	"github.com/tideland/golib/monitoring"
 )
 
 //--------------------
@@ -31,23 +34,46 @@ func TestFileLoader(t *testing.T) {
 	td := audit.NewTempDir(assert)
 	defer td.Restore()
 
-	createFile(assert, td.String(), "fa", 1000)
-	createFile(assert, td.String(), "fb", 1500)
-	createFile(assert, td.String(), "fc", 1999)
-	createFile(assert, td.String(), "fd", 2000)
-	createFile(assert, td.String(), "fe", 4000)
+	createFile(assert, td.String(), "fa", 1)
+	createFile(assert, td.String(), "fb", 2)
+	createFile(assert, td.String(), "fc", 3)
+	createFile(assert, td.String(), "fd", 4)
+	createFile(assert, td.String(), "fe", 5)
 
-	loader := cache.NewFileLoader(td.String(), 2000)
-
-	ca, err := loader("fa")
-	assert.Nil(err)
-	assert.Equal(ca.ID(), "fa")
-	fca, ok := ca.(cache.FileCacheable)
-	assert.True(ok)
-	da := make([]byte, 3000)
-	n, err := fca.Read(da)
-	assert.Nil(err)
-	assert.Equal(n, 1000)
+	mega := 1024 * 1024
+	loader := cache.NewFileLoader(td.String(), int64(3*mega))
+	tests := []struct {
+		name string
+		size int
+	}{
+		{"fa", 1},
+		{"fb", 2},
+		{"fc", 3},
+		{"fd", 4},
+		{"fe", 5},
+	}
+	for i, test := range tests {
+		assert.Logf("test #%d: %s with size %d mb", i, test.name, test.size)
+		for j := 0; j < 10; j++ {
+			m := monitoring.BeginMeasuring(test.name)
+			c, err := loader(test.name)
+			assert.Nil(err)
+			assert.Equal(c.ID(), test.name)
+			fc, ok := c.(cache.FileCacheable)
+			assert.True(ok)
+			p := make([]byte, test.size*mega)
+			rc, err := fc.ReadCloser()
+			assert.Nil(err)
+			n, err := rc.Read(p)
+			assert.Nil(err)
+			assert.Equal(n, test.size*mega)
+			err = rc.Close()
+			assert.Nil(err)
+			m.EndMeasuring()
+		}
+	}
+	time.Sleep(5 * time.Second)
+	monitoring.MeasuringPointsPrintAll()
 }
 
 //--------------------
@@ -57,8 +83,9 @@ func TestFileLoader(t *testing.T) {
 // createFile creates a file for loader tests.
 func createFile(assert audit.Assertion, dir, name string, size int) string {
 	fn := filepath.Join(dir, name)
+	mega := 1024 * 1024
 	data := []byte{}
-	for i := 0; i < size; i++ {
+	for i := 0; i < size*mega; i++ {
 		data = append(data, 'X')
 	}
 	err := ioutil.WriteFile(fn, []byte(data), 0644)

--- a/cache/loader_test.go
+++ b/cache/loader_test.go
@@ -1,0 +1,69 @@
+// Tideland Go Library - Cache - Unit Tests
+//
+// Copyright (C) 2009-2017 Frank Mueller / Tideland / Oldenburg / Germany
+//
+// All rights reserved. Use of this source code is governed
+// by the new BSD license.
+
+package cache_test
+
+//--------------------
+// IMPORTS
+//--------------------
+
+import (
+	"io/ioutil"
+	"testing"
+
+	"path/filepath"
+
+	"github.com/tideland/golib/audit"
+	"github.com/tideland/golib/cache"
+)
+
+//--------------------
+// TESTS
+//--------------------
+
+// TestFileLoader tests the loading of files.
+func TestFileLoader(t *testing.T) {
+	assert := audit.NewTestingAssertion(t, true)
+	td := audit.NewTempDir(assert)
+	defer td.Restore()
+
+	createFile(assert, td.String(), "fa", 1000)
+	createFile(assert, td.String(), "fb", 1500)
+	createFile(assert, td.String(), "fc", 1999)
+	createFile(assert, td.String(), "fd", 2000)
+	createFile(assert, td.String(), "fe", 4000)
+
+	loader := cache.NewFileLoader(td.String(), 2000)
+
+	ca, err := loader("fa")
+	assert.Nil(err)
+	assert.Equal(ca.ID(), "fa")
+	fca, ok := ca.(cache.FileCacheable)
+	assert.True(ok)
+	da := make([]byte, 3000)
+	n, err := fca.Read(da)
+	assert.Nil(err)
+	assert.Equal(n, 1000)
+}
+
+//--------------------
+// HEKPERS
+//--------------------
+
+// createFile creates a file for loader tests.
+func createFile(assert audit.Assertion, dir, name string, size int) string {
+	fn := filepath.Join(dir, name)
+	data := []byte{}
+	for i := 0; i < size; i++ {
+		data = append(data, 'X')
+	}
+	err := ioutil.WriteFile(fn, []byte(data), 0644)
+	assert.Nil(err)
+	return fn
+}
+
+// EOF

--- a/cache/tasks.go
+++ b/cache/tasks.go
@@ -116,10 +116,13 @@ func discardTask(id string, responsec responser) task {
 			return nil
 		}
 		// Delete bucket and discard Cacheable.
-		cacheable := b.cacheable
+		err := b.cacheable.Discard()
 		delete(c.buckets, id)
-		if err := cacheable.Discard(); err != nil {
-			return errors.Annotate(err, ErrDiscard, errorMessages, id)
+		if err != nil {
+			err = errors.Annotate(err, ErrDiscard, errorMessages, id)
+		}
+		responsec <- func() (Cacheable, error) {
+			return nil, err
 		}
 		return nil
 	}

--- a/cache/tasks.go
+++ b/cache/tasks.go
@@ -107,4 +107,22 @@ func lookupTask(id string, responsec responser) task {
 	}
 }
 
+// discardTask returns the task for discarding a Cacheable.
+func discardTask(id string, responsec responser) task {
+	return func(c *cache) error {
+		b, ok := c.buckets[id]
+		if !ok {
+			// Not found, so nothing to discard.
+			return nil
+		}
+		// Delete bucket and discard Cacheable.
+		cacheable := b.cacheable
+		delete(c.buckets, id)
+		if err := cacheable.Discard(); err != nil {
+			return errors.Annotate(err, ErrDiscard, errorMessages, id)
+		}
+		return nil
+	}
+}
+
 // EOF

--- a/cache/tasks.go
+++ b/cache/tasks.go
@@ -1,0 +1,83 @@
+// Tideland Go Library - Cache - Tasks
+//
+// Copyright (C) 2009-2017 Frank Mueller / Tideland / Oldenburg / Germany
+//
+// All rights reserved. Use of this source code is governed
+// by the new BSD license.
+
+package cache
+
+//--------------------
+// IMPORTS
+//--------------------
+
+import (
+	"time"
+)
+
+//--------------------
+// TASKS
+//--------------------
+
+// task contains any task a cache shall do.
+type task func(c *cache) error
+
+// cancelTask notifies the cache that a loading failed.
+func cancelTask(id string, err error) task {
+	return func(c *cache) error {
+		for _, waiter := range c.buckets[id].waiters {
+			waiter <- func() (Cacheable, error) {
+				return nil, err
+			}
+		}
+		delete(c.buckets, id)
+		return nil
+	}
+}
+
+// addTask notifies the cache that a loading succeeded.
+func addTask(id string, cacheable Cacheable) task {
+	return func(c *cache) error {
+		b := c.buckets[id]
+		b.cacheable = cacheable
+		b.status = statusLoaded
+		b.loaded = time.Now()
+		b.lastUsed = b.loaded
+		for _, waiter := range c.buckets[id].waiters {
+			waiter <- func() (Cacheable, error) {
+				return cacheable, nil
+			}
+		}
+		b.waiters = nil
+		return nil
+	}
+}
+
+// loading is the asynchronous loading function.
+func loading(c *cache, id string) {
+	cacheable, err := c.load(id)
+	if err != nil {
+		c.taskc <- cancelTask(id, err)
+	} else {
+		c.taskc <- addTask(id, cacheable)
+	}
+}
+
+// lookupTask returns the task for looking up the cache.
+func lookupTask(id string, responsec responser) task {
+	return func(c *cache) error {
+		b, ok := c.buckets[id]
+		switch {
+		case !ok:
+			c.buckets[id] = &bucket{
+				status:  statusNew,
+				waiters: []responser{responsec},
+			}
+			go loading(c, id)
+		case ok && b.status == statusNew:
+		}
+		return nil
+	}
+}
+
+// EOF


### PR DESCRIPTION
- Readesigned *cache*; now individual instances with user definable loaders
- Fixing of races in tests in *loop* and *monitoring*
- Added *IncrCallstackOffset()* to *audit.Assertion* for correct logging in functions and packages providing own test functions based on *audit*
- Code reorganisation in *audit*
- Extended *Range()* assertion in *audit* by time and duration
- Added *FailureDetail* returned by *ValidationFailer.Details()* in *audit*